### PR TITLE
`麯``麴`添加词频

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -32461,14 +32461,14 @@ use_preset_vocabulary: true
 麬	fu
 麭	pao
 麮	qu
-麯	ju
-麯	qu
+麯	ju	0%
+麯	qu	100%
 麰	mou
 麱	fu
 麲	xian
 麳	lai
-麴	ju
-麴	qu
+麴	ju	0%
+麴	qu	100%
 麵	mian
 麶	chi
 麶	li


### PR DESCRIPTION
这两个字在在线字典中都没有找到`ju`的音，暂时将它们的词频降为`0%`

是在线字典收录不全的原因吗？还是说词库收录错了，应该把这两个的`ju`音删掉？

[麴](https://www.zdic.net/hans/%E9%BA%B4)
[麯](https://www.zdic.net/hans/%E9%BA%AF)
