### PR TITLE
fix(dict): add ti for 媂

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -10979,7 +10979,8 @@ use_preset_vocabulary: true
 婿	xu
 媀	yu
 媁	wei
-媂	di
+媂	di	100%
+媂	ti	0%
 媃	rou
 媄	mei
 媅	dan


### PR DESCRIPTION
「媂」字增加读音 tí。

Reference：http://www.zdic.net/hans/%E5%AA%82