### PR TITLE
趄趄+/qie qie/, 趔趄+/lie qie/, 趄-/qu/

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -28,7 +28,7 @@
 
 ---
 name: luna_pinyin
-version: "2020.08.03"
+version: "2024.02.09"
 sort: by_weight
 use_preset_vocabulary: true
 ...
@@ -66982,6 +66982,7 @@ use_preset_vocabulary: true
 起高調	qi gao diao
 趁熟	chen shou
 趄趄	ju ju
+趄趄	qie qie
 超感覺	chao gan jue
 超詣	chao yi
 超重	chao zhong
@@ -66996,7 +66997,9 @@ use_preset_vocabulary: true
 趑趄不前	zi ju bu qian
 趑趄卻顧	zi ju que gu
 趔趄	lie ju
+趔趄	lie qie
 趔趔趄趄	lie lie ju ju
+趔趔趄趄	lie lie qie qie
 趕着增福神着棍打	gan zhe zeng fu shen zhao gun da
 趙令畤	zhao ling zhi
 趙伯駒	zhao bo ju

--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -28,7 +28,7 @@
 
 ---
 name: luna_pinyin
-version: "2024.02.09"
+version: "2024.02.10"
 sort: by_weight
 use_preset_vocabulary: true
 ...
@@ -66995,8 +66995,6 @@ use_preset_vocabulary: true
 趑趄	zi ju
 趑趄不前	zi ju bu qian
 趑趄卻顧	zi ju que gu
-趔趄	lie ju
-趔趄	lie qie
 趔趔趄趄	lie lie ju ju
 趔趔趄趄	lie lie qie qie
 趕着增福神着棍打	gan zhe zeng fu shen zhao gun da

--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -27257,7 +27257,6 @@ use_preset_vocabulary: true
 趃	die
 趄	ju
 趄	qie
-趄	qu
 超	chao
 趆	di
 趇	se


### PR DESCRIPTION
https://github.com/rime/rime-luna-pinyin/issues/59

「趔趄」一詞，查 [萌典](https://www.moedict.tw/趔趄) 爲 liè jū，《现代汉语词典》註音 liè qie。

「趄趄」一詞，《现代汉语词典》沒收，查 [萌典](https://www.moedict.tw/趄趄) 爲 jū jū，但有如下例句：
> 《負曝閑談·第五回》：「又看見昨天同船的那個少年，吃得醉醺醺的，同著兩三個朋友，腳底下 **趄趄趔趔**。」

「趄趄趔趔」的「趄」與「趔趔趄趄」應該是一樣的，所以「趄趄」也增加 qiè qiè 的讀音。

查 [萌典](https://www.moedict.tw/趄)、[漢典](https://www.zdic.net/hans/趄)、《现代汉语词典》，「趄」都只有 jū、qiè 兩個讀音，刪去 qu。
