### PR TITLE
刪去「陷」字的 xuan 音

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -30023,7 +30023,6 @@ use_preset_vocabulary: true
 陶	tao	99.94%
 陶	yao	0.06%
 陷	xian
-陷	xuan
 陸	liu	6.25%
 陸	lu	93.75%
 陹	sheng


### PR DESCRIPTION
「陷」字應該只有 xian4 一個讀音。
https://www.moedict.tw/陷
https://www.zdic.net/hans/陷