### PR TITLE
fix: 佝僂、佝僂病

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -50369,7 +50369,9 @@ use_preset_vocabulary: true
 作育菁莪	zuo yu jing e
 作諢	zuo hun
 作麼生	zuo mo sheng
+佝僂	gou lou
 佝僂	kou lou
+佝僂病	gou lou bing
 佝僂病	kou lou bing
 你哦	ni o
 你快樂	ni kuai le


### PR DESCRIPTION
補充「佝僂」在中國大陸的讀音 gōu lóu
參照：现代汉语词典（第七版） https://archive.org/details/modern-chinese-dictionary_7th-edition/page/460/mode/2up