### PR TITLE
討論：「榜」的讀音及頻率

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -15901,8 +15901,8 @@ use_preset_vocabulary: true
 榙	ta
 榚	yao
 榛	zhen
-榜	bang	50%
-榜	peng	50%
+榜	bang	100%
+榜	peng	0%
 榝	sha
 榞	yuan
 榟	zi


### PR DESCRIPTION
榜的 `peng` 讀音並不常用，這裏嘗試調爲 0%

---

https://archive.org/details/modern-chinese-dictionary_7th-edition/page/988/mode/2up
現代漢語詞典（第七版） ：榜（péng）同「搒（péng）」

https://www.moedict.tw/%E6%A6%9C
萌典：未收錄 `péng`；另有收錄 `bèng`，大致對應於《現代漢語詞典》的 `bàng` 及 `péng` 兩個讀音