### PR TITLE
fix: 徵 降低讀音 `zhi` 的頻率至小於 5%，使其不參與組詞

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -12655,8 +12655,8 @@ use_preset_vocabulary: true
 徳	de
 徴	zheng
 徴	zhi
-徵	zheng	95%
-徵	zhi	5%
+徵	zheng	96%
+徵	zhi	4%
 徶	bie
 德	de
 徸	zhong


### PR DESCRIPTION
目前輸入 `zhi xun` 會出現「徵詢」，輸入 `zhi bing` 會有「徵兵」，輸入 `zhi wen` 會有「徵文」，輸入 `zhi shou` 會有「徵收」，輸入 `zhi zhao` 會有「徵兆」。

與其一一爲含有「徵」的詞註音，我認爲不如讓 zhǐ 不參與組詞。含有徵（zhǐ）的常見詞基本都已被收錄，未來再增加的可能性很小，有的話也不難標註。

參照：https://www.moedict.tw/%E5%BE%B5