### PR TITLE
fix: 髂

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -31349,7 +31349,7 @@ use_preset_vocabulary: true
 髀	pi
 髁	ke
 髂	ka
-髂	ke
+髂	ke	0%
 髂	qia
 髃	ou
 髄	sui
@@ -70285,7 +70285,6 @@ use_preset_vocabulary: true
 髀肉復生	bi rou fu sheng
 髀骨	bi gu
 髀骶	bi di
-髂骨	ka gu
 體液	ti ye
 體癬	ti xian
 體臭	ti chou


### PR DESCRIPTION
https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4036/mode/2up 现代汉语词典（第七版）：
qià

https://www.moedict.tw/%E9%AB%82 萌典：
kà

刪除註音後，`ka gu` 與 `qia gu` 均能打出「髂骨」。讀音 `ke` 並非常用，予以降權。