### PR TITLE
fix: 秸、稭

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -21071,8 +21071,8 @@ use_preset_vocabulary: true
 秵	yin
 秶	zi
 秷	zhi
-秸	ji
-秸	jia
+秸	ji	0%
+秸	jia	0%
 秸	jie
 秹	ren
 秺	du
@@ -21133,8 +21133,9 @@ use_preset_vocabulary: true
 稪	fu
 稫	bi
 稬	nuo
-稭	ji
-稭	jia
+稭	ji	0%
+稭	jia	0%
+稭	jie
 種	zhong
 稯	zong
 稰	xu


### PR DESCRIPTION
https://archive.org/details/modern-chinese-dictionary_7th-edition/page/662/mode/2up
https://dict.revised.moe.edu.tw/dictView.jsp?ID=5554
查《现代汉语词典（第七版）》及《重編國語辭典修訂本》，「秸」只有一個常用讀音 `jie`，故將其餘讀音權重置零。

兩者皆以「稭」爲「秸」之異體字（《重編國語辭典修訂本》見 [https://dict.revised.moe.edu.tw/dictView.jsp?ID=90029](https://dict.revised.moe.edu.tw/dictView.jsp?ID=90029)），故增加 `jie` 讀音，並做同樣處理。

亦參見：字統網 [秸](https://zi.tools/zi/%E7%A7%B8) [稭](https://zi.tools/zi/%E7%A8%AD) 

（若使用最新版 `rime-essay`，則輸入 `ji gan` 或 `jia gan` 可見修改之效果。）