### PR TITLE
fix: 謬

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -26538,9 +26538,9 @@ use_preset_vocabulary: true
 謪	shang
 謫	di
 謫	zhe
-謬	miao
+謬	miao	0%
 謬	miu
-謬	niu
+謬	niu	0%
 謭	jian
 謮	ze
 謯	zha


### PR DESCRIPTION
https://archive.org/details/modern-chinese-dictionary_7th-edition/page/917/mode/2up
https://dict.revised.moe.edu.tw/dictView.jsp?ID=1422&q=1&word=%E8%AC%AC
依據《现代汉语词典（第七版）》及《重編國語辭典修訂本》，「謬」只有一個常用讀音 miù。