### PR TITLE
fix: 岫

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -11698,10 +11698,10 @@ use_preset_vocabulary: true
 岨	zu
 岩	yan
 岪	fu
-岫	di
+岫	di	0%
 岫	xiu
-岫	you
-岫	zhou
+岫	you	0%
+岫	zhou	0%
 岬	jia
 岭	ling
 岮	tuo


### PR DESCRIPTION
「岫」只有一個常用讀音 xiù。

依據：
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4476/mode/2up
《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/search.jsp?md=1&word=%E5%B2%AB#searchL

亦參見：
字統网 [岫](https://zi.tools/zi/%E5%B2%AB)