### PR TITLE
fix: 沓

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -16839,8 +16839,8 @@ use_preset_vocabulary: true
 沑	nv
 沒	mei	99.89%
 沒	mo	0.11%
-沓	miao	23.44%
-沓	ta	76.56%
+沓	da	25%
+沓	ta	75%
 沔	mian
 沕	wu
 沖	chong


### PR DESCRIPTION
依據：

《现代汉语词典（第七版）》：
dá https://archive.org/details/modern-chinese-dictionary_7th-edition/page/232/mode/2up
tà https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4260/mode/2up

《重編國語辭典修訂本》：僅有 tà
https://dict.revised.moe.edu.tw/dictView.jsp?ID=2436

《漢語大字典》：dá、tà
https://homeinmists.ilotus.org/hd/hydzd3.php?st=page_no&kw=1667 https://homeinmists.ilotus.org/hd/hydzd3.php?st=page_no&kw=1668

增加讀音 `da`。沒有查到讀音 `miao` 的出處（最初 commit 即已存在於碼表中），提議刪除。（唯一能想到的關係是和「淼」形近……）

---

Fixes https://github.com/rime/rime-luna-pinyin/issues/72

