### PR TITLE
fix: 詣

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -26269,7 +26269,6 @@ use_preset_vocabulary: true
 詡	xu
 詢	xun
 詣	yi
-詣	zhi
 詤	huang
 詥	ge
 詥	he


### PR DESCRIPTION
查閱
《漢語大字典》 https://homeinmists.ilotus.org/hd/orgpage.php?page=4228
《现代汉语词典（第七版）》 https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4554/mode/2up
《重編國語辭典修訂本》 https://dict.revised.moe.edu.tw/dictView.jsp?ID=10686
及字統网 [詣](https://zi.tools/zi/%E8%A9%A3) 頁面，均未見讀音 zhi 出處，且最初 commit 即已存在於碼表中，無從得知引入原因，因此提議刪除。