### PR TITLE
fix: 囂

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -9795,7 +9795,7 @@ use_preset_vocabulary: true
 囀	zhuan
 囁	nie
 囁	zhe
-囂	qi
+囂	ao	1%
 囂	xiao
 囃	ca
 囄	li


### PR DESCRIPTION
刪除讀音 `qi`；增加讀音 `ao` 1%。

## 依據

《重編國語辭典修訂本》：僅有 xiāo
https://dict.revised.moe.edu.tw/dictView.jsp?ID=7032

《现代汉语词典（第七版）》
aó https://archive.org/details/modern-chinese-dictionary_7th-edition/page/14/mode/2up
xiāo https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1438/mode/2up

《漢語大字典》：xiāo, aó
https://homeinmists.ilotus.org/hd/orgpage.php?page=0761

在以上來源及字統网 [囂](https://zi.tools/zi/囂) 頁面，均未找到讀音 qi 出處（最初 commit 即已存在於碼表中，因此無從得知引入原因）。