### PR TITLE
fix: 佢

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -7340,7 +7340,7 @@ use_preset_vocabulary: true
 你	ni
 佡	xian
 佡	xuan
-佢	ju
+佢	ju	5%
 佢	qu
 佣	yong
 佤	wa


### PR DESCRIPTION
使用當前 essay 的字頻輸入 `ju` 的時候，這個字排第 6 位，感覺明顯太高了。一般見到這個字都是在方言裏用作人稱代詞（通「渠」），讀 `ju` 的只查到楚簡隸定字（見下文）一種情況。
反正目前 essay 裏沒什麼詞用它組，所以大於還是小於 5% 不是十分重要，不行的話還可以再調

## 依據

《重編國語辭典修訂本》：未收錄
《现代汉语词典（第七版）》：未收錄
《漢語大字典》：僅收錄 qú https://homeinmists.ilotus.org/hd/orgpage.php?page=0153
字統网 [佢](https://zi.tools/zi/%E4%BD%A2) 頁面有「楚簡隸定字，同『居』」