### PR TITLE
fix: 樞、枢

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -15303,7 +15303,7 @@ use_preset_vocabulary: true
 枞	zong
 枟	yun
 枡	dou
-枢	qu
+枢	ou	1%
 枢	shu
 枣	zao
 枥	li
@@ -16060,7 +16060,7 @@ use_preset_vocabulary: true
 樛	jiu
 樜	zhe
 樝	zha
-樞	qu
+樞	ou	1%
 樞	shu
 樟	zhang
 樠	man


### PR DESCRIPTION
刪除讀音 `qu`；增加讀音 `ou` 1%

## 依據

《重編國語辭典修訂本》：僅收錄 shū https://dict.revised.moe.edu.tw/dictView.jsp?ID=9086
《现代汉语词典（第七版）》：僅收錄 shū https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1210/mode/2up
《漢語大字典》：shū、ōu https://homeinmists.ilotus.org/hd/orgpage.php?page=1368

在以上來源及字統网 [樞](https://zi.tools/zi/%E6%A8%9E) 頁面，均未找到讀音 qu 出處（最初 commit 即已存在於碼表中，因此無從得知引入原因）。字統网所引用的《康熙字典》似乎有一些其他的讀音，但好像沒有能切出 qu 的。