### PR TITLE
fix: 禊

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -20943,7 +20943,6 @@ use_preset_vocabulary: true
 禇	chu
 禈	hui
 禉	you
-禊	qi
 禊	xi
 禋	yan
 禋	yin


### PR DESCRIPTION
刪除讀音 `qi`

## 依據

《重編國語辭典修訂本》：xì https://dict.revised.moe.edu.tw/dictView.jsp?ID=6890
《现代汉语词典（第七版）》：xì https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1408/mode/2up
《漢語大字典》：xì https://homeinmists.ilotus.org/hd/orgpage.php?page=2572

在以上來源及字統网 [禊](https://zi.tools/zi/%E7%A6%8A) 頁面，均未找到讀音 qi 出處（最初 commit 即已存在於碼表中，因此無從得知引入原因）。字統网所引用的《康熙字典》有提到另外一個讀音「【集韻】訖黠切，音頡」，但「頡」也沒有找到 `qi` 這個讀音。