### PR TITLE
fix: 擷

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -14438,7 +14438,6 @@ use_preset_vocabulary: true
 擴	kuo
 擵	mo
 擶	jian
-擷	ji
 擷	jie
 擷	xie
 擸	la
@@ -57055,7 +57054,6 @@ use_preset_vocabulary: true
 掠食	lve shi
 採取行動	cai qu xing dong
 採摭	cai zhi
-採擷	cai jie
 採行	cai xing
 探囊胠篋	tan nang qu qie
 探本溯源	tan ben su yuan
@@ -57502,7 +57500,6 @@ use_preset_vocabulary: true
 擲色	zhi shai
 擲還	zhi huan
 擲骰子	zhi tou zi
-擷取	jie qu
 擺地攤	bai di tan
 擺番	bai fan
 擺行陣	bai hang zhen


### PR DESCRIPTION
刪除讀音 `ji`；在詞語中允許讀音 `xie`。

## 依據

《重編國語辭典修訂本》：僅收錄 jié
《现代汉语词典（第七版）》：僅收錄 xié https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1450/mode/2up 。用例中包括「采撷（= 採擷）」
《漢語大字典》：僅收錄 xié https://homeinmists.ilotus.org/hd/orgpage.php?page=2097
在以上來源及字統网 [擷](https://zi.tools/zi/%E6%93%B7) 頁面，均未找到讀音 `ji` 出處（最初 commit 即已存在於碼表中，因此無從得知引入原因）。