### PR TITLE
fix: 筱、篠

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -21505,7 +21505,6 @@ use_preset_vocabulary: true
 筯	zhu
 筰	zuo
 筱	xiao
-筱	you
 筲	shao
 筳	ting
 筴	ce
@@ -21631,7 +21630,7 @@ use_preset_vocabulary: true
 篝	gou
 篞	nie
 篟	qian
-篠	tiao
+篠	diao	1%
 篠	xiao
 篡	cuan
 篢	gong


### PR DESCRIPTION
筱：刪除讀音 `you`
篠：刪除讀音 `tiao`；增加讀音 `diao` 1%

## 依據

### 筱

《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1444/mode/2up
《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=7039
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=3172

在以上來源及字統网 [筱](https://zi.tools/zi/%E7%AD%B1) 頁面，均未找到讀音 `you` 出處（最初 commit 即已存在於碼表中，因此無從得知引入原因）。

### 篠

《现代汉语词典（第七版）》認爲「篠」是「筱」的異體字。
《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=7040
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=3201 包含一個義項通「蓧（diào）」。但不確定是否能判斷「筱」作爲「篠」的異體字時仍然通「蓧」，所以在缺乏文獻支撐的情況下沒有給「筱」也增加 `diao` 讀音。

亦參見 字統网 [篠](https://zi.tools/zi/%E7%AF%A0)。 
