### PR TITLE
fix: 厝

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -8684,8 +8684,9 @@ use_preset_vocabulary: true
 厛	ting
 厜	chui
 厜	zui
-厝	cu
+厝	cu	0%
 厝	cuo
+厝	ji	1%
 厞	fei
 原	yuan
 厠	ce


### PR DESCRIPTION
將讀音 `cu` 權重設爲 0%；增加讀音 `ji` 1%

## 依據

《现代汉语词典（第七版）》：cuò https://archive.org/details/modern-chinese-dictionary_7th-edition/page/228/mode/2up
《重編國語辭典修訂本》：cuò https://dict.revised.moe.edu.tw/dictView.jsp?ID=9874
《漢語大字典》：cuò, jí https://homeinmists.ilotus.org/hd/orgpage.php?page=0084

字統网 [厝](https://zi.tools/zi/%E5%8E%9D) 頁面所引《康熙字典》有包含內容「又【唐韻】【集韻】【正韻】𠀤倉故切，音措」。由於我學識不足，不確定是否能產生 `cu` 音，暫不刪除，而將權重降爲 0%。