### PR TITLE
fix: 謖

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -26508,7 +26508,6 @@ use_preset_vocabulary: true
 謔	xue	100%
 謕	si
 謕	ti
-謖	ji
 謖	su
 謗	bang
 謘	chi


### PR DESCRIPTION
刪除讀音 `ji`

## 依據

查閱
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4248/mode/2up
《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=10142
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=4269
及字統网 [謖](https://zi.tools/zi/%E8%AC%96) 頁面均未見讀音 `ji` 出處。查閱 git 歷史可知最初 commit 即已存在於碼表中，未知引入原因（應該是和「稷」形近吧……）