### PR TITLE
fix: 償

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -7888,7 +7888,7 @@ use_preset_vocabulary: true
 儝	qiong
 儞	er
 償	chang
-償	shang
+償	shang	0%
 儠	lie
 儡	lei
 儢	lv


### PR DESCRIPTION
設讀音 `shang` 的權重爲 0%

## 依據

現代漢語
《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=8480
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/n241/mode/2up
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=0274
均只有讀音 cháng，而字統网 [償](https://zi.tools/zi/%E5%84%9F) 所引《說文解字》、《康熙字典》等古代文獻，則由於我學識不足，無法判斷是否能產生 `shang` 音，故不刪除，而將權重設爲 0%。

---

（這個字也是平時輸入中意外出現比較多的，比如 `peisf` 輸入「配送費」的時候第二位會出現「賠償費」。）