### PR TITLE
fix: 吮

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -8892,7 +8892,6 @@ use_preset_vocabulary: true
 吭	kang	0%
 吭	keng	72.93%
 吮	shun
-吮	yun
 启	qi
 吰	hong
 吰	hu


### PR DESCRIPTION
刪除讀音 `yun`

## 依據

《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=9176
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4230/mode/2up
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=0645
均只有讀音 shǔn。字統网頁面 [吮](https://zi.tools/zi/%E5%90%AE) 所引古籍有記載一些其他古代讀音，但似乎沒有能推導出 `yun` 的。

查閱 git 歷史，讀音 `yun` 在最初 commit 即已存在於碼表中，且未知引入原因。

