### PR TITLE
fix: 驍

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -31213,10 +31213,7 @@ use_preset_vocabulary: true
 驊	hua
 驋	bo
 驌	su
-驍	nao
-驍	rao
 驍	xiao
-驍	yao
 驎	lin
 驏	chan
 驏	zhan


### PR DESCRIPTION
刪除讀音 `nao`、`rao`、`yao`

## 依據

《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=7030
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1436/mode/2up
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=4872
均只有讀音 xiāo。字統网頁面 [驍](https://zi.tools/zi/%E9%A9%8D) 所引古籍未見支持 `nao`、`rao`、`yao` 的證據。

查閱 git 歷史，讀音 `nao`、`rao`、`yao` 均於最初 commit 即已存在於碼表中，且未知引入原因。