### PR TITLE
fix: 肱

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -23119,7 +23119,6 @@ use_preset_vocabulary: true
 肯	keng	0%
 肰	ran
 肱	gong
-肱	hong
 育	yu
 肳	wen
 肴	xiao


### PR DESCRIPTION
刪除讀音 `hong`

## 依據

《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=4389
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/456/mode/2up
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=2195
均只有讀音 gōng。字統网頁面 [肱](https://zi.tools/zi/%E8%82%B1) 所引古籍未見支持 `hong` 的證據。

查閱 git 歷史，讀音 hong 最初 commit 即已存在於碼表中，且未知引入原因。