### PR TITLE
fix: 芰

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -23773,7 +23773,6 @@ use_preset_vocabulary: true
 芮	rui	100%
 芯	xin
 芰	ji
-芰	zhi
 花	hua
 芲	hua
 芲	lun


### PR DESCRIPTION
刪除讀音 `zhi`

## 依據

《重編國語辭典修訂本》：https://dict.revised.moe.edu.tw/dictView.jsp?ID=5438
《现代汉语词典（第七版）》：https://archive.org/details/modern-chinese-dictionary_7th-edition/page/616/mode/2up
《漢語大字典》：https://homeinmists.ilotus.org/hd/orgpage.php?page=3388
均只有讀音 jì。字統网頁面 [芰](https://zi.tools/zi/%E8%8A%B0) 所引古籍未見支持 `zhi` 的證據。

查閱 git 歷史，讀音 zhi 最初 commit 即已存在於碼表中，且未知引入原因。