### PR TITLE
fix: 羰基

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -63714,7 +63714,6 @@ use_preset_vocabulary: true
 羯羶	jie shan
 羯鼓	jie gu
 羯鼓催花	jie gu cui hua
-羰基	tan ji
 羶行	shan xing
 羸瘵	lei zhai
 羸露	lei lu


### PR DESCRIPTION
允許 `tang ji` 讀音

## 依據

《现代汉语词典（第七版）》：羰基 tāng jī https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4272/mode/2up
《重編國語辭典修訂本》：羰 tàn https://dict.revised.moe.edu.tw/dictView.jsp?ID=2581
羰基 tàn jī https://dict.revised.moe.edu.tw/dictView.jsp?ID=51331

查閱 git 歷史，羰的兩種讀音在碼表中最初就已存在。而羰基 `tan ji` 在 commit 817d55835f72f2d0908c5be489b68cf918cc9782 中引入，該 commit 主要內容顯然是從《萌典》導入了（臺灣）讀音數據。

而事實上臺灣應該是 tàn 與 tāng 兩種讀音並存，Youtube 上查找到
 - https://youtu.be/PkEsOh-ErL8?t=66 臺大開放式課程，讀作 tāng jī
 - https://youtu.be/KM3pVTaQ7u4?t=49 三立新聞，讀作 tàn jī

惟不知何者更常用，歡迎有識之士補充。

總之，允許 `tang ji` 讀音應當沒有問題。