### PR TITLE
fix: 蟶

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -25457,7 +25457,6 @@ use_preset_vocabulary: true
 蟳	xun
 蟴	si
 蟶	cheng
-蟶	sheng
 蟷	dang
 蟸	li
 蟹	xie


### PR DESCRIPTION
刪除讀音 `sheng`

## 依據

《现代汉语词典（第七版）》 https://archive.org/details/modern-chinese-dictionary_7th-edition/page/n257/mode/2up
《重編國語辭典修訂本》 https://dict.revised.moe.edu.tw/dictView.jsp?ID=8511
《漢語大字典》 https://homeinmists.ilotus.org/hd/orgpage.php?page=3091
以上及字統网 [蟶](https://zi.tools/zi/%E8%9F%B6) 頁面所引文獻，均未見支持讀音 sheng 的證據。