### PR TITLE
乾和：增加讀音 `qian he`（南漢年號）

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -49682,6 +49682,7 @@ use_preset_vocabulary: true
 乾剝剝	gan bo bo
 乾吊着下巴	gan diao zhe xia ba
 乾和	gan he
+乾和	qian he
 乾咳	gan ke
 乾咽	gan ye
 乾哭	gan ku


### PR DESCRIPTION
作爲酒類名稱的時候讀 gān hé，作爲年號的時候讀 qián hé。

## 依據

https://dict.revised.moe.edu.tw/dictView.jsp?ID=69909
https://zh.wikipedia.org/wiki/%E4%B9%BE%E5%92%8C