### PR TITLE
䴉：增加讀音 `huan`

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -6660,6 +6660,7 @@ use_preset_vocabulary: true
 䴆	pu
 䴇	ling
 䴈	ao
+䴉	huan
 䴉	xuan
 䴊	yi
 䴋	huan


### PR DESCRIPTION
## 依據

《现代汉语词典（第七版）》 https://archive.org/details/modern-chinese-dictionary_7th-edition/page/568/mode/2up 僅收錄 huán
《漢語大字典》 https://homeinmists.ilotus.org/hd/orgpage.php?page=4974 huán，又讀 xuán
臺灣《重編國語辭典修訂本》未收錄，在 YouTube 上檢索得到 https://www.youtube.com/watch?v=CgCDJCJgQUA 讀 xuán；https://www.youtube.com/watch?v=fP_JPz9JzkU 視頻中讀作 huán，但在下方描述中標註讀音爲 ㄒㄩㄢˊ，即 xuán。

亦參見字統网 [䴉](https://zi.tools/zi/%E4%B4%89)。

綜上，保留讀音 xuán，增補讀音 huán。