### PR TITLE
fix: 吒 咤

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -8853,7 +8853,6 @@ use_preset_vocabulary: true
 吏	li
 吐	tu
 向	xiang
-吒	chi
 吒	zha
 吓	he	0.22%
 吓	xia	99.78%
@@ -9062,7 +9061,6 @@ use_preset_vocabulary: true
 咢	e
 咣	gong
 咣	guang
-咤	chi
 咤	zha
 咥	die	50%
 咥	xi	50%


### PR DESCRIPTION
删除读音 `chi`。

## 依據

《现代汉语词典（第七版）》
吒 https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4640/mode/2up
咤 https://archive.org/details/modern-chinese-dictionary_7th-edition/page/4642/mode/2up

《漢語大字典》
吒 https://homeinmists.ilotus.org/hd/orgpage.php?page=0627
咤 https://homeinmists.ilotus.org/hd/orgpage.php?page=0672

《重編國語辭典修訂本》
吒 https://dict.revised.moe.edu.tw/dictView.jsp?ID=7664&la=0&powerMode=0
（「咤」被認爲是爲「吒」的異體字）

以上辭書均無此讀音。疑爲「叱」的讀音誤植。