### PR TITLE
fix: 斐

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -14652,7 +14652,6 @@ use_preset_vocabulary: true
 斎	zhai
 斏	lang
 斐	fei
-斐	pei
 斑	ban
 斒	ban
 斓	lan


### PR DESCRIPTION
刪除讀音 `pei`

## 依據

《现代汉语词典（第七版）》
https://archive.org/details/modern-chinese-dictionary_7th-edition/page/378/mode/2up

《漢語大字典》
https://homeinmists.ilotus.org/hd/orgpage.php?page=2327

《重編國語辭典修訂本》
https://dict.revised.moe.edu.tw/dictView.jsp?ID=1552&la=0&powerMode=0

以上辭書均無此讀音。