### PR TITLE
fix: 械

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -15628,7 +15628,7 @@ use_preset_vocabulary: true
 梭	suo
 梮	ju
 梯	ti
-械	jie
+械	jie	1%
 械	xie
 梱	kun
 梲	zhuo


### PR DESCRIPTION
設讀音 `jie` 權重爲 1%（不參與組詞）

## 依據

《重編國語辭典修訂本》：xiè 爲標準讀音，jiè 爲又音 https://dict.revised.moe.edu.tw/dictView.jsp?ID=6978&la=0&powerMode=0
《现代汉语词典（第七版）》：僅有 xiè https://archive.org/details/modern-chinese-dictionary_7th-edition/page/1452/mode/2up
《漢語大字典》：僅有 xiè https://homeinmists.ilotus.org/hd/orgpage.php?page=1296

在 YouTube 上搜尋了幾個臺灣的影片，沒有找到讀 jiè 的例子。