### PR TITLE
fix: 舛

### DIFF
--- a/luna_pinyin.dict.yaml
+++ b/luna_pinyin.dict.yaml
@@ -23593,7 +23593,6 @@ use_preset_vocabulary: true
 舙	hua
 舚	tan
 舛	chuan
-舛	jie
 舜	shun
 舝	qian
 舝	xia


### PR DESCRIPTION
刪除讀音 `jie`（疑來自「桀」之誤植）

## 依據

《现代汉语词典（第七版）》 https://archive.org/details/modern-chinese-dictionary_7th-edition/page/202/mode/2up
《漢語大字典》 https://homeinmists.ilotus.org/hd/orgpage.php?page=0924
《重編國語辭典修訂本》 https://dict.revised.moe.edu.tw/dictView.jsp?ID=8648&la=0&powerMode=0

都只有 chuǎn 一個讀音。